### PR TITLE
Allow Multiple app versions

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -10,10 +10,7 @@ android {
         versionCode 1
         versionName "0.3"
 
-        buildConfigField "String", "AUTHORITY", "\"${getAuthority()}\""
-        manifestPlaceholders = [
-                trayAuthority: getAuthority()
-        ]
+        resValue "string", "tray__authority", "com.example.preferences"
     }
 
     compileOptions {
@@ -24,21 +21,4 @@ android {
 
 dependencies {
     compile 'com.android.support:support-annotations:20.0.0'
-}
-
-String getAuthority() {
-    if (project.properties.containsKey("trayAuthority")) {
-        def authority = project.properties.get("trayAuthority")
-        if (authority.equals("com.example.preferences")) {
-            throw new Exception("com.example.preferences isn't a unique authority!!!\n" +
-                    "This will prevent your application from getting installed if another app " +
-                    "uses the same authority for Tray or any other ContentProvider.")
-        }
-        return authority
-    } else {
-        /*throw new Exception("define ext variable trayAuthority in your project build.gradle\n" +
-                "Example:\n" +
-                "ext.trayAuthority = \"com.example.preferences\"");*/
-        return "";
-    }
 }

--- a/library/src/androidTest/java/net/grandcentrix/tray/mock/MockProvider.java
+++ b/library/src/androidTest/java/net/grandcentrix/tray/mock/MockProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2015 grandcentrix GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.grandcentrix.tray.mock;
+
+import net.grandcentrix.tray.provider.TrayContract;
+
+import android.net.Uri;
+
+/**
+ * Created by pascalwelsch on 4/5/15.
+ */
+public class MockProvider {
+
+    public static final String AUTHORITY = "net.grandcentrix.tray.test";
+
+    public static Uri getConetntUri() {
+
+        final Uri authorityUri = Uri
+                .parse("content://" + AUTHORITY);
+        final Uri contentUri = Uri
+                .withAppendedPath(authorityUri, TrayContract.Preferences.BASE_PATH);
+
+        return contentUri;
+    }
+}

--- a/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayProviderHelperTest.java
+++ b/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayProviderHelperTest.java
@@ -146,29 +146,12 @@ public class TrayProviderHelperTest extends TrayProviderTestCase {
         final long start = System.currentTimeMillis();
         mProviderHelper.persist(MODULE_A, KEY_A, STRING_A);
         final List<TrayItem> list = mProviderHelper
-                .queryProvider(TrayProviderHelper.getUri(MODULE_A, KEY_A));
+                .queryProvider(mProviderHelper.getUri(MODULE_A, KEY_A));
         assertNotNull(list);
         assertEquals(1, list.size());
         TrayItem itemA = list.get(0);
         assertNotNull(itemA.created());
         assertEqualsWithin(start, itemA.created().getTime(), 100l);
-    }
-
-    public void testGenerateUri() throws Exception {
-
-        assertEquals(TrayProvider.CONTENT_URI, TrayProviderHelper.getUri(null, null));
-        assertEquals(Uri.parse(TrayProvider.CONTENT_URI + "/" + MODULE_A),
-                TrayProviderHelper.getUri(MODULE_A, null));
-        assertEquals(Uri.parse(TrayProvider.CONTENT_URI + "/" + MODULE_A + "/" + KEY_A),
-                TrayProviderHelper.getUri(MODULE_A, KEY_A));
-
-        try {
-            TrayProviderHelper.getUri(null, KEY_A);
-            Assert.fail();
-        } catch (IllegalArgumentException e) {
-            // invalid uri detected
-        }
-
     }
 
     public void testGetAll() throws Exception {
@@ -220,7 +203,7 @@ public class TrayProviderHelperTest extends TrayProviderTestCase {
     public void testQueryAll() throws Exception {
         buildQueryDatabase();
         final List<TrayItem> list = mProviderHelper
-                .queryProvider(TrayProviderHelper.getUri());
+                .queryProvider(mProviderHelper.getUri());
         assertNotNull(list);
         assertEquals(4, list.size());
     }
@@ -228,7 +211,7 @@ public class TrayProviderHelperTest extends TrayProviderTestCase {
     public void testQueryModule() throws Exception {
         buildQueryDatabase();
         final List<TrayItem> list = mProviderHelper
-                .queryProvider(TrayProviderHelper.getUri(MODULE_A));
+                .queryProvider(mProviderHelper.getUri(MODULE_A));
         assertNotNull(list);
         assertEquals(2, list.size());
         assertNotSame(list.get(0).value(), list.get(1).value());
@@ -237,7 +220,7 @@ public class TrayProviderHelperTest extends TrayProviderTestCase {
     public void testQuerySingle() throws Exception {
         buildQueryDatabase();
         final List<TrayItem> list = mProviderHelper
-                .queryProvider(TrayProviderHelper.getUri(MODULE_A, KEY_A));
+                .queryProvider(mProviderHelper.getUri(MODULE_A, KEY_A));
         assertNotNull(list);
         assertEquals(1, list.size());
         assertEquals(STRING_A, list.get(0).value());
@@ -246,7 +229,7 @@ public class TrayProviderHelperTest extends TrayProviderTestCase {
     public void testReadParsedProperties() throws Exception {
         mProviderHelper.persist(MODULE_A, KEY_A, STRING_A);
         final List<TrayItem> list = mProviderHelper
-                .queryProvider(TrayProviderHelper.getUri(MODULE_A, KEY_A));
+                .queryProvider(mProviderHelper.getUri(MODULE_A, KEY_A));
         assertNotNull(list);
         assertEquals(1, list.size());
         TrayItem itemA = list.get(0);
@@ -280,7 +263,7 @@ public class TrayProviderHelperTest extends TrayProviderTestCase {
         assertDatabaseSize(1);
 
         final List<TrayItem> list = mProviderHelper
-                .queryProvider(TrayProviderHelper.getUri(module));
+                .queryProvider(mProviderHelper.getUri(module));
         assertEquals(1, list.size());
         assertEquals(module, list.get(0).module());
         assertEquals(key, list.get(0).key());
@@ -292,7 +275,7 @@ public class TrayProviderHelperTest extends TrayProviderTestCase {
     public void testUpdateChanges() throws Exception {
         mProviderHelper.persist(MODULE_A, KEY_A, STRING_A);
         final List<TrayItem> list = mProviderHelper
-                .queryProvider(TrayProviderHelper.getUri(MODULE_A, KEY_A));
+                .queryProvider(mProviderHelper.getUri(MODULE_A, KEY_A));
         assertNotNull(list);
         assertEquals(1, list.size());
         TrayItem itemA = list.get(0);
@@ -302,7 +285,7 @@ public class TrayProviderHelperTest extends TrayProviderTestCase {
         Thread.sleep(10);
         mProviderHelper.persist(MODULE_A, KEY_A, STRING_B);
         final List<TrayItem> list2 = mProviderHelper
-                .queryProvider(TrayProviderHelper.getUri(MODULE_A, KEY_A));
+                .queryProvider(mProviderHelper.getUri(MODULE_A, KEY_A));
         assertNotNull(list2);
         assertEquals(1, list2.size());
         TrayItem itemB = list2.get(0);
@@ -313,7 +296,7 @@ public class TrayProviderHelperTest extends TrayProviderTestCase {
     public void testUpdateEqualsCreatedAtFirst() throws Exception {
         mProviderHelper.persist(MODULE_A, KEY_A, STRING_A);
         final List<TrayItem> list = mProviderHelper
-                .queryProvider(TrayProviderHelper.getUri(MODULE_A, KEY_A));
+                .queryProvider(mProviderHelper.getUri(MODULE_A, KEY_A));
         assertNotNull(list);
         assertEquals(1, list.size());
         TrayItem itemA = list.get(0);

--- a/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayProviderTestCase.java
+++ b/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayProviderTestCase.java
@@ -16,6 +16,8 @@
 
 package net.grandcentrix.tray.provider;
 
+import net.grandcentrix.tray.mock.MockProvider;
+
 import android.database.Cursor;
 import android.net.Uri;
 import android.test.ProviderTestCase2;
@@ -25,11 +27,8 @@ import android.test.ProviderTestCase2;
  */
 public class TrayProviderTestCase extends ProviderTestCase2<TrayProvider> {
 
-    public static final String AUTHORITY = "net.grandcentrix.tray.test";
-
     public TrayProviderTestCase() {
-        super(TrayProvider.class, AUTHORITY);
-        TrayProvider.setAuthority(AUTHORITY);
+        super(TrayProvider.class, MockProvider.AUTHORITY);
     }
 
     /**
@@ -38,7 +37,7 @@ public class TrayProviderTestCase extends ProviderTestCase2<TrayProvider> {
      * @param expectedSize the number of items you expect
      */
     protected void assertDatabaseSize(final long expectedSize) {
-        assertDatabaseSize(TrayProvider.CONTENT_URI, expectedSize, true);
+        assertDatabaseSize(MockProvider.getConetntUri(), expectedSize, true);
     }
 
     /**
@@ -65,7 +64,9 @@ public class TrayProviderTestCase extends ProviderTestCase2<TrayProvider> {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        getMockContentResolver().delete(TrayProvider.CONTENT_URI, null, null);
+        TrayContract.setAuthority(MockProvider.AUTHORITY);
+        TrayProvider.setAuthority(MockProvider.AUTHORITY);
+        getMockContentResolver().delete(MockProvider.getConetntUri(), null, null);
 
         assertDatabaseSize(0);
     }
@@ -73,6 +74,6 @@ public class TrayProviderTestCase extends ProviderTestCase2<TrayProvider> {
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
-        getMockContentResolver().delete(TrayProvider.CONTENT_URI, null, null);
+        getMockContentResolver().delete(MockProvider.getConetntUri(), null, null);
     }
 }

--- a/library/src/androidTest/java/net/grandcentrix/tray/storrage/TrayStorageTest.java
+++ b/library/src/androidTest/java/net/grandcentrix/tray/storrage/TrayStorageTest.java
@@ -18,6 +18,7 @@ package net.grandcentrix.tray.storrage;
 
 import junit.framework.Assert;
 
+import net.grandcentrix.tray.provider.TrayContract;
 import net.grandcentrix.tray.provider.TrayItem;
 import net.grandcentrix.tray.provider.TrayProviderHelper;
 import net.grandcentrix.tray.provider.TrayProviderTestCase;
@@ -58,7 +59,8 @@ public class TrayStorageTest extends TrayProviderTestCase {
         assertDatabaseSize(2);
 
         mStorage.clear();
-        assertDatabaseSize(TrayProviderHelper.getUri(MODULE2), 1, true);
+        final TrayProviderHelper trayProviderHelper = new TrayProviderHelper(getMockContext());
+        assertDatabaseSize(trayProviderHelper.getUri(MODULE2), 1, true);
     }
 
     public void testGetAll() throws Exception {

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
         <provider
             android:name="net.grandcentrix.tray.provider.TrayProvider"
-            android:authorities="${trayAuthority}"
+            android:authorities="@string/tray__authority"
             android:exported="false"
             android:multiprocess="false" />
 

--- a/library/src/main/java/net/grandcentrix/tray/provider/TrayContract.java
+++ b/library/src/main/java/net/grandcentrix/tray/provider/TrayContract.java
@@ -16,31 +16,64 @@
 
 package net.grandcentrix.tray.provider;
 
+import net.grandcentrix.tray.R;
+
+import android.content.Context;
+import android.net.Uri;
 import android.provider.BaseColumns;
+import android.support.annotation.NonNull;
+import android.text.TextUtils;
 
 /**
  * Created by jannisveerkamp on 17.09.14.
  */
 public class TrayContract {
 
-    public static interface Preferences {
+    public interface Preferences {
 
-        public static interface Columns extends BaseColumns {
+        interface Columns extends BaseColumns {
 
-            public static final String ID = BaseColumns._ID;
+            String ID = BaseColumns._ID;
 
-            public static final String KEY = TrayDBHelper.KEY;
+            String KEY = TrayDBHelper.KEY;
 
-            public static final String VALUE = TrayDBHelper.VALUE;
+            String VALUE = TrayDBHelper.VALUE;
 
-            public static final String MODULE = TrayDBHelper.MODULE;
+            String MODULE = TrayDBHelper.MODULE;
 
-            public static final String CREATED = TrayDBHelper.CREATED; // DATE
+            String CREATED = TrayDBHelper.CREATED; // DATE
 
-            public static final String UPDATED = TrayDBHelper.UPDATED; // DATE
+            String UPDATED = TrayDBHelper.UPDATED; // DATE
         }
 
-        public static final String BASE_PATH = "preferences";
+        String BASE_PATH = "preferences";
     }
 
+    private static String sTestAuthority;
+
+    @NonNull
+    public static Uri generateContentUri(@NonNull final Context context) {
+
+        final String authority = getAuthority(context);
+        final Uri authorityUri = Uri.parse("content://" + authority);
+        final Uri contentUri = Uri.withAppendedPath(authorityUri, Preferences.BASE_PATH);
+
+        return contentUri;
+    }
+
+    /**
+     * use this only for tests and not in production
+     *
+     * @see TrayProvider#setAuthority(String)
+     */
+    public static void setAuthority(final String authority) {
+        sTestAuthority = authority;
+    }
+
+    @NonNull
+    private static String getAuthority(@NonNull final Context context) {
+        return TextUtils.isEmpty(sTestAuthority) ?
+                context.getString(R.string.tray__authority) :
+                sTestAuthority;
+    }
 }

--- a/library/src/main/java/net/grandcentrix/tray/provider/TrayProvider.java
+++ b/library/src/main/java/net/grandcentrix/tray/provider/TrayProvider.java
@@ -16,7 +16,7 @@
 
 package net.grandcentrix.tray.provider;
 
-import net.grandcentrix.tray.BuildConfig;
+import net.grandcentrix.tray.R;
 import net.grandcentrix.tray.util.ProviderHelper;
 
 import android.content.ContentProvider;
@@ -28,7 +28,6 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
 import android.database.sqlite.SQLiteQueryBuilder;
 import android.net.Uri;
-import android.text.TextUtils;
 import android.util.Log;
 
 import java.util.Date;
@@ -46,19 +45,7 @@ public class TrayProvider extends ContentProvider {
 
     private static final String TAG = TrayProvider.class.getSimpleName();
 
-    public static String AUTHORITY;
-
-    public static Uri AUTHORITY_URI;
-
-    public static Uri CONTENT_URI;
-
     private static UriMatcher sURIMatcher;
-
-    static {
-        if (!TextUtils.isEmpty(BuildConfig.AUTHORITY)) {
-            setAuthority(BuildConfig.AUTHORITY);
-        }
-    }
 
     private TrayDBHelper mDbHelper;
 
@@ -143,12 +130,8 @@ public class TrayProvider extends ContentProvider {
 
     @Override
     public boolean onCreate() {
-        if (AUTHORITY == null) {
-            Log.w(TAG, "The AUTHORITY of the tray provider is null! "
-                    + "Set the AUTHORITY with ext.trayAuthority = \"com.example.preferences\" in your main build.gradle"
-                    + " or call TrayProvider.setAuthority(BuildConfig.APPLICATION_ID + \".tray\");");
-            return false;
-        }
+        setAuthority(getContext().getString(R.string.tray__authority));
+
         mDbHelper = new TrayDBHelper(getContext());
         return true;
     }
@@ -191,30 +174,6 @@ public class TrayProvider extends ContentProvider {
         return cursor;
     }
 
-    public static void setAuthority(final String authority) {
-        AUTHORITY = authority;
-
-        AUTHORITY_URI = Uri.parse("content://" + AUTHORITY);
-
-        CONTENT_URI = Uri.withAppendedPath(AUTHORITY_URI, TrayContract.Preferences.BASE_PATH);
-
-        sURIMatcher = new UriMatcher(UriMatcher.NO_MATCH);
-
-        sURIMatcher.addURI(TrayProvider.AUTHORITY,
-                TrayContract.Preferences.BASE_PATH,
-                ALL_PREFERENCE);
-
-        // BASE/module
-        sURIMatcher.addURI(TrayProvider.AUTHORITY,
-                TrayContract.Preferences.BASE_PATH + "/*",
-                MODULE_PREFERENCE);
-
-        // BASE/module/key
-        sURIMatcher.addURI(TrayProvider.AUTHORITY,
-                TrayContract.Preferences.BASE_PATH + "/*/*",
-                SINGLE_PREFERENCE);
-    }
-
     @Override
     public void shutdown() {
         mDbHelper.close();
@@ -246,6 +205,27 @@ public class TrayProvider extends ContentProvider {
         }
 
         return rows;
+    }
+
+    /**
+     * @see TrayContract#setAuthority(String)
+     */
+    static void setAuthority(final String authority) {
+        sURIMatcher = new UriMatcher(UriMatcher.NO_MATCH);
+
+        sURIMatcher.addURI(authority,
+                TrayContract.Preferences.BASE_PATH,
+                ALL_PREFERENCE);
+
+        // BASE/module
+        sURIMatcher.addURI(authority,
+                TrayContract.Preferences.BASE_PATH + "/*",
+                MODULE_PREFERENCE);
+
+        // BASE/module/key
+        sURIMatcher.addURI(authority,
+                TrayContract.Preferences.BASE_PATH + "/*/*",
+                SINGLE_PREFERENCE);
     }
 
     private int insertOrUpdate(final String table, final ContentValues values) {

--- a/library/src/main/java/net/grandcentrix/tray/provider/TrayProviderHelper.java
+++ b/library/src/main/java/net/grandcentrix/tray/provider/TrayProviderHelper.java
@@ -36,15 +36,18 @@ public class TrayProviderHelper {
 
     final Context mContext;
 
+    private final Uri mContentUri;
+
     public TrayProviderHelper(@NonNull final Context context) {
         mContext = context;
+        mContentUri = TrayContract.generateContentUri(context);
     }
 
     /**
      * clears <b>all</b> Preferences saved. Module independent. Erases everything
      */
     public void clear() {
-        mContext.getContentResolver().delete(TrayProvider.CONTENT_URI, null, null);
+        mContext.getContentResolver().delete(mContentUri, null, null);
     }
 
     /**
@@ -89,7 +92,7 @@ public class TrayProviderHelper {
                     .extendSelectionArgs(selectionArgs, new String[]{moduleName});
         }
 
-        mContext.getContentResolver().delete(TrayProvider.CONTENT_URI, selection, selectionArgs);
+        mContext.getContentResolver().delete(mContentUri, selection, selectionArgs);
     }
 
     /**
@@ -98,24 +101,27 @@ public class TrayProviderHelper {
      * @return all Preferences as list.
      */
     public List<TrayItem> getAll() {
-        return queryProvider(TrayProvider.CONTENT_URI);
+        return queryProvider(mContentUri);
     }
 
+    public Uri getContentUri() {
+        return mContentUri;
+    }
 
-    public static Uri getUri() {
+    public Uri getUri() {
         return getUri(null, null);
     }
 
-    public static Uri getUri(final String module) {
+    public Uri getUri(final String module) {
         return getUri(module, null);
     }
 
-    public static Uri getUri(@Nullable final String module, @Nullable final String key) {
+    public Uri getUri(@Nullable final String module, @Nullable final String key) {
         if (module == null && key != null) {
             throw new IllegalArgumentException(
                     "key without module is not valid. Look into the TryProvider for valid Uris");
         }
-        final Uri.Builder builder = TrayProvider.CONTENT_URI
+        final Uri.Builder builder = mContentUri
                 .buildUpon();
         if (module != null) {
             builder.appendPath(module);
@@ -136,7 +142,7 @@ public class TrayProviderHelper {
             return;
         }
 
-        final Uri uri = TrayProvider.CONTENT_URI
+        final Uri uri = mContentUri
                 .buildUpon()
                 .appendPath(module)
                 .appendPath(key)

--- a/library/src/main/java/net/grandcentrix/tray/storage/TrayStorage.java
+++ b/library/src/main/java/net/grandcentrix/tray/storage/TrayStorage.java
@@ -54,21 +54,22 @@ public class TrayStorage extends ModularizedStorage<TrayItem> {
 
     @Override
     public void clear() {
-        final Uri uri = TrayProvider.CONTENT_URI.buildUpon().appendPath(getModule()).build();
+        final Uri uri = mProviderHelper.getContentUri().buildUpon().appendPath(getModule()).build();
         mContext.getContentResolver().delete(uri, null, null);
     }
 
     @Override
     @Nullable
     public TrayItem get(@NonNull final String key) {
-        final Uri uri = TrayProviderHelper.getUri(getModule(), key);
+        final Uri uri = mProviderHelper.getUri(getModule(), key);
         final List<TrayItem> prefs = mProviderHelper.queryProvider(uri);
         return prefs.size() == 1 ? prefs.get(0) : null;
     }
 
     @Override
     public Collection<TrayItem> getAll() {
-        return mProviderHelper.queryProvider(TrayProviderHelper.getUri(getModule()));
+        final Uri uri = mProviderHelper.getUri(getModule());
+        return mProviderHelper.queryProvider(uri);
     }
 
     @Override
@@ -88,7 +89,7 @@ public class TrayStorage extends ModularizedStorage<TrayItem> {
             throw new IllegalArgumentException(
                     "null is not valid. use clear to delete all preferences");
         }
-        final Uri uri = TrayProviderHelper.getUri(getModule(), key);
+        final Uri uri = mProviderHelper.getUri(getModule(), key);
         mContext.getContentResolver().delete(uri, null, null);
     }
 }


### PR DESCRIPTION
Allow Multiple app versions (same app with different package names) and setting the authority from the android project
I totally removed the `ext.trayAuthority` part from the library. It was working but wasn't a good solution.

The new way uses a string resource to define the authority. This let's the user of the lib define the authority for tray in the app `build.gradle` file. This is the normal way and the only dependency for the lib. No more static initializers for in `Application#onCreate()`.

``` groovy
resValue "string", "tray__authority", "my.company.app.tray"
```

this leads to a single change in the current implementation. It's only possible to read the authority as string resource with a `Context`. That's no problem for the `ContentProvider` itself because the `UriMatcher` can be initialized in `onCreate(Context)`.
There is only one other point where the Authority is needed, the `TrayProviderHelper` class. There were the static `TrayProviderHelper#getUri(...)` methods. Moving them to member functions (`TrayProviderHelper` requires a context in the constructor) was easy because the helper was only used when a context was available.

It's now possible to define different authorities for different build flavors. The error where an app couldn't be installed due to the same provider authority is now solved.
