### PR TITLE
fix travis InstallException

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.2'
+        classpath 'com.android.tools.build:gradle:1.2.3'
         classpath 'com.novoda:bintray-release:0.2.10'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -37,6 +37,10 @@ android {
     lintOptions {
         abortOnError false
     }
+
+    adbOptions {
+        timeOutInMs 30000
+    }
 }
 
 dependencies {


### PR DESCRIPTION
added bigger timeout to prevent com.android.ddmlib.InstallException on travis and other (slow) environments

https://code.google.com/p/android/issues/detail?id=104305
com.android.ddmlib.InstallException
	at com.android.ddmlib.Device.installPackage(Device.java:840)
Caused by: com.android.ddmlib.TimeoutException
	at com.android.ddmlib.AdbHelper.write(AdbHelper.java:819)