### PR TITLE
Fix deletion of non string migrated shared preferences.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: android
+
+env:
+  global:
+    - ADB_INSTALL_TIMEOUT=20 # minutes (2 minutes by default)
+
 android:
   components:
     # Uncomment the lines below if you want to

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
-        classpath 'com.novoda:bintray-release:0.2.10'
+        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.novoda:bintray-release:0.3.4'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -35,7 +35,7 @@ android {
     }
 
     adbOptions {
-        timeOutInMs 30000
+        timeOutInMs 300000
     }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -7,7 +7,7 @@ def final int VERSION_CODE = 9
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         minSdkVersion 15

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -7,7 +7,7 @@ def final int VERSION_CODE = 9
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         minSdkVersion 15

--- a/library/src/androidTest/java/net/grandcentrix/tray/core/SharedPreferencesImportTest.java
+++ b/library/src/androidTest/java/net/grandcentrix/tray/core/SharedPreferencesImportTest.java
@@ -134,6 +134,17 @@ public class SharedPreferencesImportTest extends TrayProviderTestCase {
         assertEquals(DATA, mSharedPrefs.getString("key", "default")); // data is deleted
     }
 
+    public void testPostMigrateIntegerCorrect() throws Exception {
+        final int DATA = 13;
+        mSharedPrefs.edit().putInt("key", DATA).commit();
+        final SharedPreferencesImport sharedPreferencesImport = new SharedPreferencesImport(
+                getContext(), SHARED_PREF_NAME, "key", "trayKey");
+        final TrayItem trayItem = mock(TrayItem.class);
+        when(trayItem.value()).thenReturn(Integer.toString(DATA));
+        sharedPreferencesImport.onPostMigrate(trayItem);
+        assertEquals(1, mSharedPrefs.getInt("key", 1)); // data is deleted
+    }
+
     public void testPostMigrateWithNull() throws Exception {
         final String DATA = "data";
         mSharedPrefs.edit().putString("key", DATA).commit();

--- a/library/src/main/java/net/grandcentrix/tray/core/SharedPreferencesImport.java
+++ b/library/src/main/java/net/grandcentrix/tray/core/SharedPreferencesImport.java
@@ -76,7 +76,7 @@ public class SharedPreferencesImport implements TrayMigration {
             TrayLog.wtf("migration " + this + " failed, saved data in tray is null");
             return;
         }
-        if (equals(trayItem.value(), getData())) {
+        if (equals(trayItem.value(), getData().toString())) {
             TrayLog.v("removing key '" + mSharedPrefsKey + "' from SharedPreferences '"
                     + mSharedPrefsName + "'");
             mPreferences.edit().remove(mSharedPrefsKey).apply();

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -21,6 +21,10 @@ android {
         }
     }
 
+    lintOptions {
+        abortOnError false
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         applicationId "net.grandcentrix.tray.sample"
@@ -33,9 +33,9 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.0.1'
+    compile 'com.android.support:appcompat-v7:23.4.0'
     compile 'io.reactivex:rxjava:1.0.15'
-    
+
     //compile 'net.grandcentrix.tray:tray:1.0.0-rc1'
     // for development
     compile project(':library')

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         applicationId "net.grandcentrix.tray.sample"
@@ -33,9 +33,9 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.4.0'
+    compile 'com.android.support:appcompat-v7:23.0.1'
     compile 'io.reactivex:rxjava:1.0.15'
-
+    
     //compile 'net.grandcentrix.tray:tray:1.0.0-rc1'
     // for development
     compile project(':library')


### PR DESCRIPTION
The equality check before the deletion of migrated preferences only worked for strings as Tray stores everything as a string. The `toString()` ensures it works for boxed types as well.