### PR TITLE
return empty list when the cursor is null when doing query

### DIFF
--- a/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayProviderHelperTest.java
+++ b/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayProviderHelperTest.java
@@ -238,18 +238,14 @@ public class TrayProviderHelperTest extends TrayProviderTestCase {
         assertNotSame(list.get(0).value(), list.get(1).value());
     }
 
-    public void testQueryProviderWithUnregisteredProvider() throws Exception {
+    public void testQueryGotCursorNull() throws Exception {
         final Context context = mock(Context.class);
         final ContentResolver contentResolver = mock(ContentResolver.class);
         when(context.getContentResolver()).thenReturn(contentResolver);
         final TrayProviderHelper trayProviderHelper = new TrayProviderHelper(context);
         final Uri uri = mTrayUri.get();
-        try {
-            trayProviderHelper.queryProvider(uri);
-            fail();
-        } catch (IllegalStateException e) {
-            assertTrue(e.getMessage().contains(uri.toString()));
-        }
+        List<TrayItem> trayItems = trayProviderHelper.queryProvider(uri);
+        assertEquals(0, trayItems.size());
     }
 
     public void testQuerySingle() throws Exception {

--- a/library/src/main/java/net/grandcentrix/tray/provider/TrayProviderHelper.java
+++ b/library/src/main/java/net/grandcentrix/tray/provider/TrayProviderHelper.java
@@ -133,26 +133,19 @@ public class TrayProviderHelper {
      *
      * @param uri path to data
      * @return list of items
-     * @throws IllegalStateException something is wrong with the provider/database
      */
     @NonNull
     public List<TrayItem> queryProvider(@NonNull final Uri uri)
             throws IllegalStateException {
         final Cursor cursor = mContext.getContentResolver().query(uri, null, null, null, null);
-
-        // Return Preference if found
-        if (cursor == null) {
-            throw new IllegalStateException(
-                    "could not access stored data with uri " + uri
-                            + ". Is the provider registered in the manifest of your application?");
-        }
-
         final ArrayList<TrayItem> list = new ArrayList<>();
-        for (boolean hasItem = cursor.moveToFirst(); hasItem; hasItem = cursor.moveToNext()) {
-            final TrayItem trayItem = cursorToTrayItem(cursor);
-            list.add(trayItem);
+        if (cursor != null) {
+            for (boolean hasItem = cursor.moveToFirst(); hasItem; hasItem = cursor.moveToNext()) {
+                final TrayItem trayItem = cursorToTrayItem(cursor);
+                list.add(trayItem);
+            }
+            cursor.close();
         }
-        cursor.close();
         return list;
     }
 


### PR DESCRIPTION
For this: [issue #50 ](https://github.com/grandcentrix/tray/issues/50)
Since the [ContentResolver.query()](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/core/java/android/content/ContentResolver.java) do have chance to return null cursor. 
I guess return an empty list is better than throw an exception.

According to our app's crash log, this crash most happens during the Dagger Inject process, in the `getVersion()` method. That's the situation we inject a class but may throw exception in the constructor, which we can't do a try-catch to handle.