### PR TITLE
TrayUri work in general context

### DIFF
--- a/library/src/main/java/net/grandcentrix/tray/provider/TrayUri.java
+++ b/library/src/main/java/net/grandcentrix/tray/provider/TrayUri.java
@@ -24,7 +24,7 @@ class TrayUri {
         private TrayStorage.Type mType = TrayStorage.Type.UNDEFINED;
 
         public Builder(final Context context) {
-            mContext = context.getApplicationContext();
+            mContext = (context.getApplicationContext() == null ? context : context.getApplicationContext());
         }
 
         public Uri build() {


### PR DESCRIPTION
Try to get the application context, but fall back to the general context if null