### PR TITLE
Set unique authority prefix automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,23 +153,14 @@ dependencies {
 
 ##### Set the authority
 
-To set the authority you need to override the string resource of the library with `resValue` in your `build.gradle`
+To set the unique authority you need to set applicationId in your `build.gradle`
 ```java
 android {
     ...
     defaultConfig {
-        applicationId "your.app.id" // this is your unique applicationId
-
-        resValue "string", "tray__authority", "${applicationId}.tray" // add this to set a unique tray authority based on your applicationId
+        applicationId "your.app.id" // this is your unique applicationId as authority prefix
     }
 }
-```
-
-Clean your project afterwards to generate the `/build/generated/res/generated/BUILDTYPE/values/generated.xml` which should then contain the following value:
-
-```xml
-    <!-- Values from default config. -->
-    <item name="tray__authority" type="string">your.app.id.tray</item>
 ```
 
 Tray is based on a ContentProvider. A ContentProvider needs a **unique** authority. When you use the same authority for multiple apps you will be unable to install the app due to a authority conflict with the error message:

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -15,8 +15,6 @@ android {
         versionCode VERSION_CODE
         versionName VERSION_NAME
 
-        resValue "string", "tray__authority", "com.example.preferences"
-
         testInstrumentationRunner = "android.support.test.runner.AndroidJUnitRunner"
     }
 

--- a/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayContractTest.java
+++ b/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayContractTest.java
@@ -1,10 +1,18 @@
 package net.grandcentrix.tray.provider;
 
-import org.mockito.Mockito;
-
 import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.ProviderInfo;
 import android.net.Uri;
 import android.test.AndroidTestCase;
+import android.test.mock.MockContext;
+import android.test.mock.MockPackageManager;
+
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Created by pascalwelsch on 4/12/15.
@@ -31,6 +39,39 @@ public class TrayContractTest extends AndroidTestCase {
         TrayContract.setAuthority("blubb");
         uri = TrayContract.generateInternalContentUri(Mockito.mock(Context.class));
         assertEquals("content://blubb/internal_preferences", uri.toString());
+    }
+
+    public void testGenerateContentUri2() throws Exception {
+        MockContext mockContext = new MockContext() {
+            @Override
+            public Context getApplicationContext() {
+                return this;
+            }
+
+            @Override
+            public String getPackageName() {
+                return getContext().getPackageName();
+            }
+
+            @Override
+            public PackageManager getPackageManager() {
+                return new MockPackageManager() {
+                    @Override
+                    public List<PackageInfo> getInstalledPackages(int flags) {
+                        if (flags == PackageManager.GET_PROVIDERS) {
+                            PackageInfo packageInfo = new PackageInfo();
+                            ProviderInfo providerInfo = new ProviderInfo();
+                            providerInfo.authority = getContext().getPackageName() + ".tray";
+                            packageInfo.providers = new ProviderInfo[]{providerInfo};
+                            return Collections.singletonList(packageInfo);
+                        }
+                        return super.getInstalledPackages(flags);
+                    }
+                };
+            }
+        };
+        Uri uri = TrayContract.generateContentUri(mockContext);
+        assertEquals("content://" + getContext().getPackageName() + ".tray/preferences", uri.toString());
     }
 
     @Override

--- a/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayProviderTest.java
+++ b/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayProviderTest.java
@@ -16,13 +16,12 @@
 
 package net.grandcentrix.tray.provider;
 
-import net.grandcentrix.tray.core.TrayStorage;
-
 import android.content.ContentValues;
-import android.content.pm.ProviderInfo;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.net.Uri;
+
+import net.grandcentrix.tray.core.TrayStorage;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -38,7 +37,7 @@ public class TrayProviderTest extends TrayProviderTestCase {
 
     public TrayContentProvider startupProvider() {
         final TrayContentProvider provider = new TrayContentProvider();
-        provider.attachInfo(getProviderMockContext(), new ProviderInfo());
+        provider.attachInfo(getProviderMockContext(), getMockProviderInfo());
         assertTrue(provider.onCreate());
         assertTrue(provider.mUserDbHelper.getWritableDatabase().isOpen());
         return provider;
@@ -178,7 +177,8 @@ public class TrayProviderTest extends TrayProviderTestCase {
     public void testQueryWrongUri() throws Exception {
         final Uri googleUri = Uri.parse("http://www.google.com");
         final TrayContentProvider trayContentProvider = new TrayContentProvider();
-        trayContentProvider.attachInfo(getProviderMockContext(), new ProviderInfo());
+
+        trayContentProvider.attachInfo(getProviderMockContext(), getMockProviderInfo());
         try {
             trayContentProvider.query(googleUri, null, null, null, null);
             fail();

--- a/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayProviderTestCase.java
+++ b/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayProviderTestCase.java
@@ -16,14 +16,12 @@
 
 package net.grandcentrix.tray.provider;
 
-import net.grandcentrix.tray.BuildConfig;
-import net.grandcentrix.tray.core.TrayStorage;
-
 import android.annotation.TargetApi;
 import android.content.ContentProvider;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.pm.ProviderInfo;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteException;
 import android.net.Uri;
@@ -31,6 +29,9 @@ import android.os.Build;
 import android.test.IsolatedContext;
 import android.test.ProviderTestCase2;
 import android.test.mock.MockContentResolver;
+
+import net.grandcentrix.tray.BuildConfig;
+import net.grandcentrix.tray.core.TrayStorage;
 
 import java.util.HashMap;
 
@@ -109,6 +110,12 @@ public abstract class TrayProviderTestCase extends ProviderTestCase2<TrayContent
 
     public TrayIsolatedContext getProviderMockContext() {
         return mIsolatedContext;
+    }
+
+    public ProviderInfo getMockProviderInfo() {
+        ProviderInfo providerInfo = new ProviderInfo();
+        providerInfo.authority = getProviderMockContext().getPackageName() + ".tray";
+        return providerInfo;
     }
 
     protected void assertDatabaseSize(final TrayStorage.Type type, final long expectedSize) {

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
         <provider
             android:name=".provider.TrayContentProvider"
-            android:authorities="@string/tray__authority"
+            android:authorities="${applicationId}.tray"
             android:exported="false"
             android:multiprocess="false" />
 

--- a/library/src/main/java/net/grandcentrix/tray/provider/TrayContentProvider.java
+++ b/library/src/main/java/net/grandcentrix/tray/provider/TrayContentProvider.java
@@ -16,12 +16,11 @@
 
 package net.grandcentrix.tray.provider;
 
-import net.grandcentrix.tray.R;
-import net.grandcentrix.tray.core.TrayLog;
-
 import android.content.ContentProvider;
 import android.content.ContentValues;
+import android.content.Context;
 import android.content.UriMatcher;
+import android.content.pm.ProviderInfo;
 import android.database.Cursor;
 import android.database.DatabaseUtils;
 import android.database.MergeCursor;
@@ -29,6 +28,8 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteQueryBuilder;
 import android.net.Uri;
 import android.support.annotation.NonNull;
+
+import net.grandcentrix.tray.core.TrayLog;
 
 import java.util.Date;
 
@@ -210,11 +211,15 @@ public class TrayContentProvider extends ContentProvider {
 
     @Override
     public boolean onCreate() {
-        setAuthority(getContext().getString(R.string.tray__authority));
-
         mUserDbHelper = new TrayDBHelper(getContext(), true);
         mDeviceDbHelper = new TrayDBHelper(getContext(), false);
         return true;
+    }
+
+    @Override
+    public void attachInfo(Context context, ProviderInfo info) {
+        super.attachInfo(context, info);
+        setAuthority(info.authority);
     }
 
     @Override

--- a/library/src/main/java/net/grandcentrix/tray/provider/TrayContract.java
+++ b/library/src/main/java/net/grandcentrix/tray/provider/TrayContract.java
@@ -16,9 +16,10 @@
 
 package net.grandcentrix.tray.provider;
 
-import net.grandcentrix.tray.R;
-
 import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.ProviderInfo;
 import android.net.Uri;
 import android.provider.BaseColumns;
 import android.support.annotation.NonNull;
@@ -120,8 +121,20 @@ class TrayContract {
 
     @NonNull
     private static String getAuthority(@NonNull final Context context) {
-        return TextUtils.isEmpty(sTestAuthority) ?
-                context.getString(R.string.tray__authority) :
-                sTestAuthority;
+        if (!TextUtils.isEmpty(sTestAuthority)) {
+            return sTestAuthority;
+        }
+        for (PackageInfo pack : context.getPackageManager().getInstalledPackages(PackageManager.GET_PROVIDERS)) {
+            ProviderInfo[] providers = pack.providers;
+            if (providers != null) {
+                for (ProviderInfo provider : providers) {
+                    if (TextUtils.equals(provider.authority,
+                            context.getApplicationContext().getPackageName() + ".tray")) {
+                        return provider.authority;
+                    }
+                }
+            }
+        }
+        return "com.example.preferences";
     }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -10,8 +10,6 @@ android {
         targetSdkVersion 23
         versionCode 1
         versionName "1.1"
-
-        resValue "string", "tray__authority", "net.grandcentrix.tray.sample.preferences"
     }
 
     buildTypes {


### PR DESCRIPTION
If developer include tray library in their own library, it's difficult to get app applicationId in library build.gradle. For users who use that library may don't have to realize what `tray__authority` is.
