### PR TITLE
Make sure preference key value is not empty.

### DIFF
--- a/library/src/androidTest/java/net/grandcentrix/tray/TrayTest.java
+++ b/library/src/androidTest/java/net/grandcentrix/tray/TrayTest.java
@@ -16,6 +16,8 @@
 
 package net.grandcentrix.tray;
 
+import junit.framework.Assert;
+
 import net.grandcentrix.tray.core.TrayItem;
 import net.grandcentrix.tray.mock.TestTrayModulePreferences;
 import net.grandcentrix.tray.provider.MockProvider;
@@ -118,6 +120,17 @@ public class TrayTest extends TrayProviderTestCase {
         final Tray tray = new Tray(getProviderMockContext());
 
         tray.clearBut(new AppPreferences(getProviderMockContext()));
+    }
+
+    public void testEmptyKey() throws Exception {
+        final TestTrayModulePreferences module =
+                new TestTrayModulePreferences(getProviderMockContext(), "module");
+        try {
+            module.put("", "test");
+            Assert.fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("Preference key value cannot be empty.", e.getMessage());
+        }
     }
 
     public void testClearModules() throws Exception {

--- a/library/src/androidTest/java/net/grandcentrix/tray/core/PreferenceTest.java
+++ b/library/src/androidTest/java/net/grandcentrix/tray/core/PreferenceTest.java
@@ -16,6 +16,7 @@
 
 package net.grandcentrix.tray.core;
 
+import junit.framework.Assert;
 import junit.framework.TestCase;
 
 import net.grandcentrix.tray.mock.MockTrayStorage;
@@ -301,5 +302,15 @@ public class PreferenceTest extends TestCase {
         Mockito.when(storage.wipe()).thenReturn(false);
         final MockSimplePreferences preferences = new MockSimplePreferences(storage, 1);
         assertFalse(preferences.wipe());
+    }
+
+    public void testEmptyKey() throws Exception {
+        final MockSimplePreferences mockPreference = new MockSimplePreferences(1);
+        try {
+            mockPreference.put("", "test");
+            Assert.fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("Preference key value cannot be empty.", e.getMessage());
+        }
     }
 }

--- a/library/src/main/java/net/grandcentrix/tray/core/PreferenceAccessor.java
+++ b/library/src/main/java/net/grandcentrix/tray/core/PreferenceAccessor.java
@@ -172,6 +172,7 @@ public interface PreferenceAccessor<T> {
      * @param key   the key to map the value
      * @param value the data to save
      * @return whether the put was successful
+     * @throws IllegalArgumentException empty string value was passed as the key
      */
     boolean put(@NonNull final String key, @Nullable final String value);
 
@@ -181,6 +182,7 @@ public interface PreferenceAccessor<T> {
      * @param key   the key to map the value
      * @param value the data to save
      * @return whether the put was successful
+     * @throws IllegalArgumentException empty string value was passed as the key
      */
     boolean put(@NonNull final String key, final int value);
 
@@ -190,6 +192,7 @@ public interface PreferenceAccessor<T> {
      * @param key   the key to map the value
      * @param value the data to save
      * @return whether the put was successful
+     * @throws IllegalArgumentException empty string value was passed as the key
      */
     boolean put(@NonNull final String key, final float value);
 
@@ -199,6 +202,7 @@ public interface PreferenceAccessor<T> {
      * @param key   the key to map the value
      * @param value the data to save
      * @return whether the put was successful
+     * @throws IllegalArgumentException empty string value was passed as the key
      */
     boolean put(@NonNull final String key, final long value);
 
@@ -208,6 +212,7 @@ public interface PreferenceAccessor<T> {
      * @param key   the key to map the value
      * @param value the data to save
      * @return whether the put was successful
+     * @throws IllegalArgumentException empty string value was passed as the key
      */
     boolean put(@NonNull final String key, final boolean value);
 

--- a/library/src/main/java/net/grandcentrix/tray/core/Preferences.java
+++ b/library/src/main/java/net/grandcentrix/tray/core/Preferences.java
@@ -303,7 +303,7 @@ public abstract class Preferences<T, S extends PreferenceStorage<T>>
                 || data == null;
     }
 
-    boolean putData(String key, Object value) {
+    private boolean putData(String key, Object value) {
         if (TextUtils.isEmpty(key)) {
             throw new IllegalArgumentException("Preference key value cannot be empty.");
         }

--- a/library/src/main/java/net/grandcentrix/tray/core/Preferences.java
+++ b/library/src/main/java/net/grandcentrix/tray/core/Preferences.java
@@ -18,6 +18,7 @@ package net.grandcentrix.tray.core;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.text.TextUtils;
 
 import java.util.Collection;
 
@@ -131,7 +132,7 @@ public abstract class Preferences<T, S extends PreferenceStorage<T>>
             return false;
         }
         v("put '" + key + "=\"" + value + "\"' into " + this);
-        return getStorage().put(key, value);
+        return putData(key, value);
     }
 
     @Override
@@ -140,7 +141,7 @@ public abstract class Preferences<T, S extends PreferenceStorage<T>>
             return false;
         }
         v("put '" + key + "=" + value + "' into " + this);
-        return getStorage().put(key, value);
+        return putData(key, value);
     }
 
     @Override
@@ -149,7 +150,7 @@ public abstract class Preferences<T, S extends PreferenceStorage<T>>
             return false;
         }
         v("put '" + key + "=" + value + "' into " + this);
-        return getStorage().put(key, value);
+        return putData(key, value);
     }
 
     @Override
@@ -158,7 +159,7 @@ public abstract class Preferences<T, S extends PreferenceStorage<T>>
             return false;
         }
         v("put '" + key + "=" + value + "' into " + this);
-        return getStorage().put(key, value);
+        return putData(key, value);
     }
 
     @Override
@@ -167,7 +168,7 @@ public abstract class Preferences<T, S extends PreferenceStorage<T>>
             return false;
         }
         v("put '" + key + "=" + value + "' into " + this);
-        return getStorage().put(key, value);
+        return putData(key, value);
     }
 
     public boolean remove(@NonNull final String key) {
@@ -300,5 +301,12 @@ public abstract class Preferences<T, S extends PreferenceStorage<T>>
                 || data instanceof Float
                 || data instanceof Boolean
                 || data == null;
+    }
+
+    boolean putData(String key, Object value) {
+        if (TextUtils.isEmpty(key)) {
+            throw new IllegalArgumentException("Preference key value cannot be empty.");
+        }
+        return getStorage().put(key, value);
     }
 }


### PR DESCRIPTION
Fixes #64 

This `PR` makes the following changes:
- When a preference key is empty, an `illegalArgumentException` is
    thrown. This prevents empty string being passed to the underling storage
    engine from throwing an error with an unclear message.
- Add tests for this fix.