### PR TITLE
Weaken Parameter type for clearBut Methods

### DIFF
--- a/library/src/main/java/net/grandcentrix/tray/Tray.java
+++ b/library/src/main/java/net/grandcentrix/tray/Tray.java
@@ -16,6 +16,7 @@
 
 package net.grandcentrix.tray;
 
+import net.grandcentrix.tray.core.AbstractTrayPreference;
 import net.grandcentrix.tray.core.Preferences;
 import net.grandcentrix.tray.core.TrayItem;
 import net.grandcentrix.tray.provider.TrayProviderHelper;
@@ -79,7 +80,7 @@ public class Tray {
      * @param modules modules excluded when deleting preferences
      * @return true when successfully cleared the not stated modules
      */
-    public boolean clearBut(TrayPreferences... modules) {
+    public boolean clearBut(AbstractTrayPreference... modules) {
         return mProviderHelper.clearBut(modules);
     }
 

--- a/library/src/main/java/net/grandcentrix/tray/provider/TrayProviderHelper.java
+++ b/library/src/main/java/net/grandcentrix/tray/provider/TrayProviderHelper.java
@@ -17,6 +17,7 @@
 package net.grandcentrix.tray.provider;
 
 import net.grandcentrix.tray.TrayPreferences;
+import net.grandcentrix.tray.core.AbstractTrayPreference;
 import net.grandcentrix.tray.core.TrayException;
 import net.grandcentrix.tray.core.TrayItem;
 
@@ -70,11 +71,11 @@ public class TrayProviderHelper {
      * @return true when successful, false otherwise. true doesn't indicate that something got
      * cleared, it just means no error occurred
      */
-    public boolean clearBut(TrayPreferences... modules) {
+    public boolean clearBut(AbstractTrayPreference... modules) {
         String selection = null;
         String[] selectionArgs = new String[]{};
 
-        for (final TrayPreferences module : modules) {
+        for (final AbstractTrayPreference module : modules) {
             if (module == null) {
                 continue;
             }


### PR DESCRIPTION
`clearBut()` methods should only need an instance of `AbstractTrayPreference` instead the concrete implementation `TrayPreference`.

Since we are only weakening the type of the parameter it should not break anything.

This is needed in case you're using an alternative Implementation.

@passsy 