### PR TITLE
Update minimum sdk version to 8 (FROYO)

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -10,7 +10,7 @@ android {
     buildToolsVersion "23.0.1"
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 8
         targetSdkVersion 23
         versionCode VERSION_CODE
         versionName VERSION_NAME


### PR DESCRIPTION
Update library required system minimum API level from API 15
(ICE_CREAM_SANDWICH_MR1) to API 8 (FROYO).

This update will let this library to be available for usage in many more android projects which require lower API level than 15.

When attempting to decrease the `minSdkVersion` attribute value to < 8, (for example, 7) the following gradle build error occurs:
```
Error:Execution failed for task ':library:processDebugAndroidTestManifest'.
> java.lang.RuntimeException: Manifest merger failed : uses-sdk:minSdkVersion 7 cannot be smaller than version 8 declared in library [com.android.support.test:runner:0.4]
	Suggestion: use tools:overrideLibrary="android.support.test" to force usage
```

This is the **lowest API level** available without any changes to either source code or dependencies.
This update passes all instrumented tests.