### PR TITLE
ApplicationId as authority and add ability to override it 

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,16 @@ android {
 }
 ```
 
+We will always use your `applicationId` plus `.tray` as suffix for the authority.
+If you don't want to use the "default" authority you can define your own with the following code inside your `AndroidManifest`:
+```xml
+<provider
+    android:name="net.grandcentrix.tray.provider.TrayContentProvider"
+    android:authorities="your.custom.authority"
+    android:exported="false"
+    tools:replace="android:authorities" />
+```
+
 Tray is based on a ContentProvider. A ContentProvider needs a **unique** authority. When you use the same authority for multiple apps you will be unable to install the app due to a authority conflict with the error message:
 
 ```

--- a/README.md
+++ b/README.md
@@ -153,23 +153,14 @@ dependencies {
 
 ##### Set the authority
 
-To set the authority you need to override the string resource of the library with `resValue` in your `build.gradle`
+To set the unique authority you need to set applicationId in your `build.gradle`
 ```java
 android {
     ...
     defaultConfig {
-        applicationId "your.app.id" // this is your unique applicationId
-
-        resValue "string", "tray__authority", "${applicationId}.tray" // add this to set a unique tray authority based on your applicationId
+        applicationId "your.app.id" // this is your unique applicationId as authority prefix
     }
 }
-```
-
-Clean your project afterwards to generate the `/build/generated/res/generated/BUILDTYPE/values/generated.xml` which should then contain the following value:
-
-```xml
-    <!-- Values from default config. -->
-    <item name="tray__authority" type="string">your.app.id.tray</item>
 ```
 
 Tray is based on a ContentProvider. A ContentProvider needs a **unique** authority. When you use the same authority for multiple apps you will be unable to install the app due to a authority conflict with the error message:

--- a/README.md
+++ b/README.md
@@ -151,37 +151,7 @@ dependencies {
 
 ```
 
-##### Set the authority
-
-To set the unique authority you need to set applicationId in your `build.gradle`
-```java
-android {
-    ...
-    defaultConfig {
-        applicationId "your.app.id" // this is your unique applicationId as authority prefix
-    }
-}
-```
-
-We will always use your `applicationId` plus `.tray` as suffix for the authority.
-If you don't want to use the "default" authority you can define your own with the following code inside your `AndroidManifest`:
-```xml
-<provider
-    android:name="net.grandcentrix.tray.provider.TrayContentProvider"
-    android:authorities="your.custom.authority"
-    android:exported="false"
-    tools:replace="android:authorities" />
-```
-
-Tray is based on a ContentProvider. A ContentProvider needs a **unique** authority. When you use the same authority for multiple apps you will be unable to install the app due to a authority conflict with the error message:
-
-```
-Failure [INSTALL_FAILED_CONFLICTING_PROVIDER]
-```
-
-Changing the authority from one version to another app version is no problem! Tray always uses the same database.
-
-If you are using different applicationIds for different buildTypes of flavors read [this](https://blog.grandcentrix.net/how-to-install-different-app-variants-on-one-android-device/) article.
+More on the `ContentProvider` configuration can be found in the [wiki](https://github.com/grandcentrix/tray/wiki/Custom-Authority)
 
 ## Project state
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -15,8 +15,6 @@ android {
         versionCode VERSION_CODE
         versionName VERSION_NAME
 
-        resValue "string", "tray__authority", "com.example.preferences"
-
         testInstrumentationRunner = "android.support.test.runner.AndroidJUnitRunner"
     }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -15,6 +15,8 @@ android {
         versionCode VERSION_CODE
         versionName VERSION_NAME
 
+        resValue "string", "tray__authority", "legacyTrayAuthority"
+
         testInstrumentationRunner = "android.support.test.runner.AndroidJUnitRunner"
     }
 

--- a/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayContractTest.java
+++ b/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayContractTest.java
@@ -1,7 +1,14 @@
 package net.grandcentrix.tray.provider;
 
+import android.content.res.Resources;
 import android.net.Uri;
 import android.test.AndroidTestCase;
+import android.test.mock.MockContext;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by pascalwelsch on 4/12/15.
@@ -34,6 +41,7 @@ public class TrayContractTest extends AndroidTestCase {
 
     public void testGenerateInternalContentUri_WithoutProviderAuthority_AppShouldCrash()
             throws Exception {
+        final String authority = TrayContentProvider.mAuthority;
         TrayContentProvider.mAuthority = null;
 
         try {
@@ -43,6 +51,21 @@ public class TrayContractTest extends AndroidTestCase {
             assertTrue(e.getMessage().contains("Internal tray error"));
         }
 
+        TrayContentProvider.mAuthority = authority;
+    }
+
+    public void testLogcatOutput_ShouldPrintIfTrayAuthorityIsNotDefault() throws Exception {
+        final MockContext stuff = new MockContext() {
+            @Override
+            public Resources getResources() {
+                final Resources mockResources = mock(Resources.class);
+                when(mockResources.getString(anyInt())).thenReturn(eq("notDefaultTrayAuthority"));
+                return mockResources;
+            }
+        };
+        TrayContract.generateInternalContentUri(stuff);
+
+        assertTrue(true);
     }
 
     @Override

--- a/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayContractTest.java
+++ b/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayContractTest.java
@@ -1,11 +1,14 @@
 package net.grandcentrix.tray.provider;
 
 import net.grandcentrix.tray.R;
+import net.grandcentrix.tray.core.TrayRuntimeException;
 
+import android.content.pm.ProviderInfo;
 import android.content.res.Resources;
 import android.net.Uri;
-import android.test.AndroidTestCase;
-import android.test.mock.MockContext;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -14,7 +17,8 @@ import static org.mockito.Mockito.when;
 /**
  * Created by pascalwelsch on 4/12/15.
  */
-public class TrayContractTest extends AndroidTestCase {
+public class TrayContractTest extends TrayProviderTestCase {
+
 
     public void testConstruction() throws Exception {
         new TrayContract();
@@ -25,7 +29,7 @@ public class TrayContractTest extends AndroidTestCase {
         assertEquals("content://net.grandcentrix.tray.preferences.test/preferences",
                 uri.toString());
 
-        TrayContract.setAuthority("asdf");
+        TrayContract.sAuthority = "asdf";
         uri = TrayContract.generateContentUri(getContext());
         assertEquals("content://asdf/preferences", uri.toString());
     }
@@ -35,37 +39,94 @@ public class TrayContractTest extends AndroidTestCase {
         assertEquals("content://net.grandcentrix.tray.preferences.test/internal_preferences",
                 uri.toString());
 
-        TrayContract.setAuthority("blubb");
+        TrayContract.sAuthority = "blubb";
         uri = TrayContract.generateInternalContentUri(getContext());
         assertEquals("content://blubb/internal_preferences", uri.toString());
     }
 
-    public void testGenerateInternalContentUri_WithoutProviderAuthority_AppShouldCrash()
+    public void testGenerateInternalContentUri_WithCorrectProvider_ShouldWork()
             throws Exception {
-        final String authority = TrayContentProvider.mAuthority;
-        TrayContentProvider.mAuthority = null;
+
+        final List<ProviderInfo> mockProviders = new ArrayList<>();
+
+        ProviderInfo wrongInfo = new ProviderInfo();
+        wrongInfo.authority = "wrong";
+        wrongInfo.name = "wrong";
+        mockProviders.add(wrongInfo);
+
+        ProviderInfo info = new ProviderInfo();
+        info.authority = "my.custom.authority";
+        info.name = TrayContentProvider.class.getName();
+        mockProviders.add(info);
+
+        getProviderMockContext().setProviderInfos(mockProviders);
+
+        TrayContract.generateInternalContentUri(getProviderMockContext());
+
+        assertEquals("my.custom.authority", TrayContract.sAuthority);
+    }
+
+    public void testGenerateInternalContentUri_WithWrongProviders_AppShouldCrash()
+            throws Exception {
+
+        final List<ProviderInfo> mockProviders = new ArrayList<>();
+        ProviderInfo info = new ProviderInfo();
+        info.name = "wrongName";
+        mockProviders.add(info);
+
+        getProviderMockContext().setProviderInfos(mockProviders);
 
         try {
-            TrayContract.generateInternalContentUri(getContext());
-            fail();
-        } catch (RuntimeException e) {
+            TrayContract.generateInternalContentUri(getProviderMockContext());
+            fail("did not throw");
+        } catch (TrayRuntimeException e) {
             assertTrue(e.getMessage().contains("Internal tray error"));
         }
+    }
 
-        TrayContentProvider.mAuthority = authority;
+    public void testGenerateInternalContentUri_WithoutEmptyProviders_AppShouldCrash()
+            throws Exception {
+
+        final List<ProviderInfo> mockProviders = new ArrayList<>();
+        getProviderMockContext().setProviderInfos(mockProviders);
+
+        try {
+            TrayContract.generateInternalContentUri(getProviderMockContext());
+            fail("did not throw");
+        } catch (TrayRuntimeException e) {
+            assertTrue(e.getMessage().contains("Internal tray error"));
+        }
+    }
+
+    public void testGenerateInternalContentUri_WithoutProvider_AppShouldCrash()
+            throws Exception {
+
+        try {
+            TrayContract.generateInternalContentUri(getProviderMockContext());
+            fail("did not throw");
+        } catch (TrayRuntimeException e) {
+            assertTrue(e.getMessage().contains("Internal tray error"));
+        }
     }
 
     public void testLogcatOutput_ShouldPrintIfTrayAuthorityIsNotDefault() throws Exception {
+
+        final List<ProviderInfo> mockProviders = new ArrayList<>();
+        ProviderInfo info = new ProviderInfo();
+        info.authority = "my.custom.authority";
+        info.name = TrayContentProvider.class.getName();
+        mockProviders.add(info);
+
+        getProviderMockContext().setProviderInfos(mockProviders);
+
         final Resources mockResources = mock(Resources.class);
         when(mockResources.getString(R.string.tray__authority))
-                .thenReturn("notDefaultTrayAuthority");
-        final MockContext mockContext = new MockContext() {
-            @Override
-            public Resources getResources() {
-                return mockResources;
-            }
-        };
-        TrayContract.generateInternalContentUri(mockContext);
+                .thenReturn("NOTlegacyTrayAuthority");
+        getProviderMockContext().setResources(mockResources);
+
+        TrayContract.generateInternalContentUri(getProviderMockContext());
+
+        // no further assertions possible just executing the logging branch
 
         verify(mockResources).getString(R.string.tray__authority);
     }
@@ -73,8 +134,6 @@ public class TrayContractTest extends AndroidTestCase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        TrayContract.setAuthority(null);
+        TrayContract.sAuthority = null;
     }
-
-
 }

--- a/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayContractTest.java
+++ b/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayContractTest.java
@@ -1,18 +1,10 @@
 package net.grandcentrix.tray.provider;
 
-import android.content.Context;
-import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
-import android.content.pm.ProviderInfo;
-import android.net.Uri;
-import android.test.AndroidTestCase;
-import android.test.mock.MockContext;
-import android.test.mock.MockPackageManager;
-
 import org.mockito.Mockito;
 
-import java.util.Collections;
-import java.util.List;
+import android.content.Context;
+import android.net.Uri;
+import android.test.AndroidTestCase;
 
 /**
  * Created by pascalwelsch on 4/12/15.
@@ -25,7 +17,8 @@ public class TrayContractTest extends AndroidTestCase {
 
     public void testGenerateContentUri() throws Exception {
         Uri uri = TrayContract.generateContentUri(getContext());
-        assertEquals("content://net.grandcentrix.tray.preferences.test/preferences", uri.toString());
+        assertEquals("content://net.grandcentrix.tray.preferences.test/preferences",
+                uri.toString());
 
         TrayContract.setAuthority("asdf");
         uri = TrayContract.generateContentUri(Mockito.mock(Context.class));
@@ -34,11 +27,25 @@ public class TrayContractTest extends AndroidTestCase {
 
     public void testGenerateInternalContentUri() throws Exception {
         Uri uri = TrayContract.generateInternalContentUri(getContext());
-        assertEquals("content://net.grandcentrix.tray.preferences.test/internal_preferences", uri.toString());
+        assertEquals("content://net.grandcentrix.tray.preferences.test/internal_preferences",
+                uri.toString());
 
         TrayContract.setAuthority("blubb");
         uri = TrayContract.generateInternalContentUri(Mockito.mock(Context.class));
         assertEquals("content://blubb/internal_preferences", uri.toString());
+    }
+
+    public void testGenerateInternalContentUri_WithoutProviderAuthority_AppShouldCrash()
+            throws Exception {
+        TrayContentProvider.mAuthority = null;
+
+        try {
+            TrayContract.generateInternalContentUri(Mockito.mock(Context.class));
+            fail();
+        } catch (RuntimeException e) {
+            assertTrue(e.getMessage().contains("Internal tray error"));
+        }
+
     }
 
     @Override

--- a/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayContractTest.java
+++ b/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayContractTest.java
@@ -1,13 +1,14 @@
 package net.grandcentrix.tray.provider;
 
+import net.grandcentrix.tray.R;
+
 import android.content.res.Resources;
 import android.net.Uri;
 import android.test.AndroidTestCase;
 import android.test.mock.MockContext;
 
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -55,17 +56,18 @@ public class TrayContractTest extends AndroidTestCase {
     }
 
     public void testLogcatOutput_ShouldPrintIfTrayAuthorityIsNotDefault() throws Exception {
-        final MockContext stuff = new MockContext() {
+        final Resources mockResources = mock(Resources.class);
+        when(mockResources.getString(R.string.tray__authority))
+                .thenReturn("notDefaultTrayAuthority");
+        final MockContext mockContext = new MockContext() {
             @Override
             public Resources getResources() {
-                final Resources mockResources = mock(Resources.class);
-                when(mockResources.getString(anyInt())).thenReturn(eq("notDefaultTrayAuthority"));
                 return mockResources;
             }
         };
-        TrayContract.generateInternalContentUri(stuff);
+        TrayContract.generateInternalContentUri(mockContext);
 
-        assertTrue(true);
+        verify(mockResources).getString(R.string.tray__authority);
     }
 
     @Override

--- a/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayContractTest.java
+++ b/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayContractTest.java
@@ -1,8 +1,5 @@
 package net.grandcentrix.tray.provider;
 
-import org.mockito.Mockito;
-
-import android.content.Context;
 import android.net.Uri;
 import android.test.AndroidTestCase;
 
@@ -21,7 +18,7 @@ public class TrayContractTest extends AndroidTestCase {
                 uri.toString());
 
         TrayContract.setAuthority("asdf");
-        uri = TrayContract.generateContentUri(Mockito.mock(Context.class));
+        uri = TrayContract.generateContentUri(getContext());
         assertEquals("content://asdf/preferences", uri.toString());
     }
 
@@ -31,7 +28,7 @@ public class TrayContractTest extends AndroidTestCase {
                 uri.toString());
 
         TrayContract.setAuthority("blubb");
-        uri = TrayContract.generateInternalContentUri(Mockito.mock(Context.class));
+        uri = TrayContract.generateInternalContentUri(getContext());
         assertEquals("content://blubb/internal_preferences", uri.toString());
     }
 
@@ -40,7 +37,7 @@ public class TrayContractTest extends AndroidTestCase {
         TrayContentProvider.mAuthority = null;
 
         try {
-            TrayContract.generateInternalContentUri(Mockito.mock(Context.class));
+            TrayContract.generateInternalContentUri(getContext());
             fail();
         } catch (RuntimeException e) {
             assertTrue(e.getMessage().contains("Internal tray error"));

--- a/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayContractTest.java
+++ b/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayContractTest.java
@@ -1,10 +1,18 @@
 package net.grandcentrix.tray.provider;
 
-import org.mockito.Mockito;
-
 import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.ProviderInfo;
 import android.net.Uri;
 import android.test.AndroidTestCase;
+import android.test.mock.MockContext;
+import android.test.mock.MockPackageManager;
+
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Created by pascalwelsch on 4/12/15.
@@ -31,6 +39,39 @@ public class TrayContractTest extends AndroidTestCase {
         TrayContract.setAuthority("blubb");
         uri = TrayContract.generateInternalContentUri(Mockito.mock(Context.class));
         assertEquals("content://blubb/internal_preferences", uri.toString());
+    }
+
+    public void testGenerateContentUri2() throws Exception {
+        MockContext mockContext = new MockContext() {
+            @Override
+            public Context getApplicationContext() {
+                return this;
+            }
+
+            @Override
+            public String getPackageName() {
+                return getContext().getPackageName();
+            }
+
+            @Override
+            public PackageManager getPackageManager() {
+                return new MockPackageManager() {
+                    @Override
+                    public List<PackageInfo> getInstalledPackages(int flags) {
+                        if (flags == PackageManager.GET_PROVIDERS) {
+                            PackageInfo packageInfo = new PackageInfo();
+                            ProviderInfo providerInfo = new ProviderInfo();
+                            providerInfo.authority = getContext().getPackageName() + ".tray";
+                            packageInfo.providers = new ProviderInfo[]{providerInfo};
+                            return Collections.singletonList(packageInfo);
+                        }
+                        return super.getInstalledPackages(flags);
+                    }
+                };
+            }
+        };
+        Uri uri = TrayContract.generateContentUri(mockContext);
+        assertEquals("content://" + getContext().getPackageName() + ".tray/preferences", uri.toString());
     }
 
     @Override

--- a/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayContractTest.java
+++ b/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayContractTest.java
@@ -25,7 +25,7 @@ public class TrayContractTest extends AndroidTestCase {
 
     public void testGenerateContentUri() throws Exception {
         Uri uri = TrayContract.generateContentUri(getContext());
-        assertEquals("content://com.example.preferences/preferences", uri.toString());
+        assertEquals("content://net.grandcentrix.tray.preferences.test/preferences", uri.toString());
 
         TrayContract.setAuthority("asdf");
         uri = TrayContract.generateContentUri(Mockito.mock(Context.class));
@@ -34,44 +34,11 @@ public class TrayContractTest extends AndroidTestCase {
 
     public void testGenerateInternalContentUri() throws Exception {
         Uri uri = TrayContract.generateInternalContentUri(getContext());
-        assertEquals("content://com.example.preferences/internal_preferences", uri.toString());
+        assertEquals("content://net.grandcentrix.tray.preferences.test/internal_preferences", uri.toString());
 
         TrayContract.setAuthority("blubb");
         uri = TrayContract.generateInternalContentUri(Mockito.mock(Context.class));
         assertEquals("content://blubb/internal_preferences", uri.toString());
-    }
-
-    public void testGenerateContentUri2() throws Exception {
-        MockContext mockContext = new MockContext() {
-            @Override
-            public Context getApplicationContext() {
-                return this;
-            }
-
-            @Override
-            public String getPackageName() {
-                return getContext().getPackageName();
-            }
-
-            @Override
-            public PackageManager getPackageManager() {
-                return new MockPackageManager() {
-                    @Override
-                    public List<PackageInfo> getInstalledPackages(int flags) {
-                        if (flags == PackageManager.GET_PROVIDERS) {
-                            PackageInfo packageInfo = new PackageInfo();
-                            ProviderInfo providerInfo = new ProviderInfo();
-                            providerInfo.authority = getContext().getPackageName() + ".tray";
-                            packageInfo.providers = new ProviderInfo[]{providerInfo};
-                            return Collections.singletonList(packageInfo);
-                        }
-                        return super.getInstalledPackages(flags);
-                    }
-                };
-            }
-        };
-        Uri uri = TrayContract.generateContentUri(mockContext);
-        assertEquals("content://" + getContext().getPackageName() + ".tray/preferences", uri.toString());
     }
 
     @Override

--- a/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayProviderTest.java
+++ b/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayProviderTest.java
@@ -16,13 +16,12 @@
 
 package net.grandcentrix.tray.provider;
 
-import net.grandcentrix.tray.core.TrayStorage;
-
 import android.content.ContentValues;
-import android.content.pm.ProviderInfo;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.net.Uri;
+
+import net.grandcentrix.tray.core.TrayStorage;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -38,7 +37,7 @@ public class TrayProviderTest extends TrayProviderTestCase {
 
     public TrayContentProvider startupProvider() {
         final TrayContentProvider provider = new TrayContentProvider();
-        provider.attachInfo(getProviderMockContext(), new ProviderInfo());
+        provider.attachInfo(getProviderMockContext(), getMockProviderInfo());
         assertTrue(provider.onCreate());
         assertTrue(provider.mUserDbHelper.getWritableDatabase().isOpen());
         return provider;
@@ -178,7 +177,8 @@ public class TrayProviderTest extends TrayProviderTestCase {
     public void testQueryWrongUri() throws Exception {
         final Uri googleUri = Uri.parse("http://www.google.com");
         final TrayContentProvider trayContentProvider = new TrayContentProvider();
-        trayContentProvider.attachInfo(getProviderMockContext(), new ProviderInfo());
+
+        trayContentProvider.attachInfo(getProviderMockContext(), getMockProviderInfo());
         try {
             trayContentProvider.query(googleUri, null, null, null, null);
             fail();

--- a/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayProviderTestCase.java
+++ b/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayProviderTestCase.java
@@ -16,12 +16,17 @@
 
 package net.grandcentrix.tray.provider;
 
+import net.grandcentrix.tray.BuildConfig;
+import net.grandcentrix.tray.core.TrayStorage;
+
 import android.annotation.TargetApi;
 import android.content.ContentProvider;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.content.pm.ProviderInfo;
+import android.content.res.Resources;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteException;
 import android.net.Uri;
@@ -29,11 +34,10 @@ import android.os.Build;
 import android.test.IsolatedContext;
 import android.test.ProviderTestCase2;
 import android.test.mock.MockContentResolver;
-
-import net.grandcentrix.tray.BuildConfig;
-import net.grandcentrix.tray.core.TrayStorage;
+import android.test.mock.MockPackageManager;
 
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Created by pascalwelsch on 11/21/14.
@@ -45,7 +49,11 @@ public abstract class TrayProviderTestCase extends ProviderTestCase2<TrayContent
 
         boolean mHasMockResolver = false;
 
+        private List<ProviderInfo> mProviderInfos;
+
         private HashMap<String, ContentProvider> mProviders = new HashMap<>();
+
+        private Resources mResources;
 
         private final Context mTargetContext;
 
@@ -99,6 +107,30 @@ public abstract class TrayProviderTestCase extends ProviderTestCase2<TrayContent
 
         public boolean isHasMockResolver() {
             return mHasMockResolver;
+        }
+
+        public void setProviderInfos(List<ProviderInfo> providerInfos) {
+            mProviderInfos = providerInfos;
+        }
+
+        @Override
+        public PackageManager getPackageManager() {
+            return new MockPackageManager() {
+                @Override
+                public List<ProviderInfo> queryContentProviders(final String processName,
+                        final int uid, final int flags) {
+                    return mProviderInfos;
+                }
+            };
+        }
+
+        @Override
+        public Resources getResources() {
+            return mResources != null ? mResources : super.getResources();
+        }
+
+        public void setResources(final Resources resources) {
+            mResources = resources;
         }
     }
 
@@ -189,7 +221,7 @@ public abstract class TrayProviderTestCase extends ProviderTestCase2<TrayContent
     }
 
     private void cleanupProvider() {
-        TrayContract.setAuthority(MockProvider.AUTHORITY);
+        TrayContract.sAuthority = MockProvider.AUTHORITY;
         TrayContentProvider.setAuthority(MockProvider.AUTHORITY);
         try {
             getMockContentResolver().delete(MockProvider.getUserContentUri(), null, null);

--- a/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayProviderTestCase.java
+++ b/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayProviderTestCase.java
@@ -16,14 +16,12 @@
 
 package net.grandcentrix.tray.provider;
 
-import net.grandcentrix.tray.BuildConfig;
-import net.grandcentrix.tray.core.TrayStorage;
-
 import android.annotation.TargetApi;
 import android.content.ContentProvider;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.pm.ProviderInfo;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteException;
 import android.net.Uri;
@@ -31,6 +29,9 @@ import android.os.Build;
 import android.test.IsolatedContext;
 import android.test.ProviderTestCase2;
 import android.test.mock.MockContentResolver;
+
+import net.grandcentrix.tray.BuildConfig;
+import net.grandcentrix.tray.core.TrayStorage;
 
 import java.util.HashMap;
 
@@ -109,6 +110,12 @@ public abstract class TrayProviderTestCase extends ProviderTestCase2<TrayContent
 
     public TrayIsolatedContext getProviderMockContext() {
         return mIsolatedContext;
+    }
+
+    public ProviderInfo getMockProviderInfo() {
+        ProviderInfo providerInfo = new ProviderInfo();
+        providerInfo.authority = getProviderMockContext().getPackageName() + ".tray";
+        return providerInfo;
     }
 
     protected void assertDatabaseSize(final TrayStorage.Type type, final long expectedSize) {

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
         <provider
             android:name=".provider.TrayContentProvider"
-            android:authorities="@string/tray__authority"
+            android:authorities="${applicationId}.tray"
             android:exported="false"
             android:multiprocess="false" />
 

--- a/library/src/main/java/net/grandcentrix/tray/provider/TrayContentProvider.java
+++ b/library/src/main/java/net/grandcentrix/tray/provider/TrayContentProvider.java
@@ -30,7 +30,6 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteQueryBuilder;
 import android.net.Uri;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import java.util.Date;
 
@@ -66,8 +65,6 @@ public class TrayContentProvider extends ContentProvider {
     TrayDBHelper mDeviceDbHelper;
 
     TrayDBHelper mUserDbHelper;
-
-    static String mAuthority;
 
     @Override
     public int delete(final Uri uri, String selection, String[] selectionArgs) {
@@ -222,8 +219,8 @@ public class TrayContentProvider extends ContentProvider {
     @Override
     public void attachInfo(Context context, ProviderInfo info) {
         super.attachInfo(context, info);
-        mAuthority = info.authority;
-        setAuthority(mAuthority);
+        setAuthority(info.authority);
+        TrayLog.v("TrayContentProvider registered for authority: " + info.authority);
     }
 
     @Override

--- a/library/src/main/java/net/grandcentrix/tray/provider/TrayContentProvider.java
+++ b/library/src/main/java/net/grandcentrix/tray/provider/TrayContentProvider.java
@@ -16,12 +16,11 @@
 
 package net.grandcentrix.tray.provider;
 
-import net.grandcentrix.tray.R;
-import net.grandcentrix.tray.core.TrayLog;
-
 import android.content.ContentProvider;
 import android.content.ContentValues;
+import android.content.Context;
 import android.content.UriMatcher;
+import android.content.pm.ProviderInfo;
 import android.database.Cursor;
 import android.database.DatabaseUtils;
 import android.database.MergeCursor;
@@ -29,6 +28,8 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteQueryBuilder;
 import android.net.Uri;
 import android.support.annotation.NonNull;
+
+import net.grandcentrix.tray.core.TrayLog;
 
 import java.util.Date;
 
@@ -210,11 +211,15 @@ public class TrayContentProvider extends ContentProvider {
 
     @Override
     public boolean onCreate() {
-        setAuthority(getContext().getString(R.string.tray__authority));
-
         mUserDbHelper = new TrayDBHelper(getContext(), true);
         mDeviceDbHelper = new TrayDBHelper(getContext(), false);
         return true;
+    }
+
+    @Override
+    public void attachInfo(Context context, ProviderInfo info) {
+        super.attachInfo(context, info);
+        setAuthority(info.authority);
     }
 
     @Override

--- a/library/src/main/java/net/grandcentrix/tray/provider/TrayContentProvider.java
+++ b/library/src/main/java/net/grandcentrix/tray/provider/TrayContentProvider.java
@@ -16,6 +16,8 @@
 
 package net.grandcentrix.tray.provider;
 
+import net.grandcentrix.tray.core.TrayLog;
+
 import android.content.ContentProvider;
 import android.content.ContentValues;
 import android.content.Context;
@@ -28,8 +30,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteQueryBuilder;
 import android.net.Uri;
 import android.support.annotation.NonNull;
-
-import net.grandcentrix.tray.core.TrayLog;
+import android.support.annotation.Nullable;
 
 import java.util.Date;
 
@@ -65,6 +66,8 @@ public class TrayContentProvider extends ContentProvider {
     TrayDBHelper mDeviceDbHelper;
 
     TrayDBHelper mUserDbHelper;
+
+    static String mAuthority;
 
     @Override
     public int delete(final Uri uri, String selection, String[] selectionArgs) {
@@ -219,7 +222,8 @@ public class TrayContentProvider extends ContentProvider {
     @Override
     public void attachInfo(Context context, ProviderInfo info) {
         super.attachInfo(context, info);
-        setAuthority(info.authority);
+        mAuthority = info.authority;
+        setAuthority(mAuthority);
     }
 
     @Override

--- a/library/src/main/java/net/grandcentrix/tray/provider/TrayContentProvider.java
+++ b/library/src/main/java/net/grandcentrix/tray/provider/TrayContentProvider.java
@@ -327,9 +327,6 @@ public class TrayContentProvider extends ContentProvider {
         return !"false".equals(backup);
     }
 
-    /**
-     * @see TrayContract#setAuthority(String)
-     */
     static void setAuthority(final String authority) {
         sURIMatcher = new UriMatcher(UriMatcher.NO_MATCH);
 

--- a/library/src/main/java/net/grandcentrix/tray/provider/TrayContract.java
+++ b/library/src/main/java/net/grandcentrix/tray/provider/TrayContract.java
@@ -16,11 +16,14 @@
 
 package net.grandcentrix.tray.provider;
 
+import net.grandcentrix.tray.R;
+
 import android.content.Context;
 import android.net.Uri;
 import android.provider.BaseColumns;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
+import android.util.Log;
 
 /**
  * Contract defining the data in the {@link TrayContentProvider}. Use {@link TrayProviderHelper} to
@@ -85,6 +88,24 @@ class TrayContract {
         return generateContentUri(context, InternalPreferences.BASE_PATH);
     }
 
+    /**
+     * Inform if someone use the old way to set or override the authority
+     */
+    private static void checkOldWayToSetAuthority(final @NonNull Context context) {
+        if (!"legacyTrayAuthority".equals(context.getString(R.string.tray__authority))) {
+            Log.e("Tray", "You are using a legacy tray method\n"
+                    + "#########################################\n"
+                    + "#########################################\n"
+                    + "#########################################\n"
+                    + "Don't override the authority with `tray__authority`\n"
+                    + "To change the default authority override it inside the AndroidManifest\n"
+                    + "See https://github.com/grandcentrix/tray#set-the-authority for instructions\n"
+                    + "#########################################\n"
+                    + "#########################################\n"
+                    + "#########################################\n");
+        }
+    }
+
     @NonNull
     private static Uri generateContentUri(@NonNull final Context context, final String basepath) {
 
@@ -100,6 +121,8 @@ class TrayContract {
         if (!TextUtils.isEmpty(sTestAuthority)) {
             return sTestAuthority;
         }
+
+        checkOldWayToSetAuthority(context);
 
         final String authority = TrayContentProvider.mAuthority;
         if (!TextUtils.isEmpty(authority)) {

--- a/library/src/main/java/net/grandcentrix/tray/provider/TrayContract.java
+++ b/library/src/main/java/net/grandcentrix/tray/provider/TrayContract.java
@@ -17,14 +17,10 @@
 package net.grandcentrix.tray.provider;
 
 import android.content.Context;
-import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
-import android.content.pm.ProviderInfo;
 import android.net.Uri;
 import android.provider.BaseColumns;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
-import android.util.Log;
 
 /**
  * Contract defining the data in the {@link TrayContentProvider}. Use {@link TrayProviderHelper} to
@@ -89,30 +85,10 @@ class TrayContract {
         return generateContentUri(context, InternalPreferences.BASE_PATH);
     }
 
-    private static void checkForDefaultAuthority(final @NonNull String authority) {
-        if (authority.equals("com.example.preferences")) {
-            Log.e("Tray", "Tray authority not defined\n"
-                    + "#########################################\n"
-                    + "#########################################\n"
-                    + "#########################################\n"
-                    + "Don't use the default authority from the tray library. Two apps with the same tray authority can't be installed on the same device!\n\n"
-                    + "Override the authority adding a string resource to your project with key: `tray__authority`.\n"
-                    + "The simples way is to add it via gradle:\n"
-                    + ".\n"
-                    + "defaultConfig {\n"
-                    + "resValue \"string\", \"tray__authority\", \"<your.app.package.tray>\"\n"
-                    + "}\n"
-                    + "#########################################\n"
-                    + "#########################################\n"
-                    + "#########################################");
-        }
-    }
-
     @NonNull
     private static Uri generateContentUri(@NonNull final Context context, final String basepath) {
 
         final String authority = getAuthority(context);
-        checkForDefaultAuthority(authority);
         final Uri authorityUri = Uri.parse("content://" + authority);
         //noinspection UnnecessaryLocalVariable
         final Uri contentUri = Uri.withAppendedPath(authorityUri, basepath);
@@ -126,10 +102,12 @@ class TrayContract {
         }
 
         final String authority = TrayContentProvider.mAuthority;
-        if(!TextUtils.isEmpty(authority)) {
+        if (!TextUtils.isEmpty(authority)) {
             return authority;
         }
 
-        return "com.example.preferences";
+        // Should never happen. Otherwise we implemented tray in a wrong way!
+        throw new RuntimeException("Internal tray error."
+                + " Please fill an issue at https://github.com/grandcentrix/tray/issues");
     }
 }

--- a/library/src/main/java/net/grandcentrix/tray/provider/TrayContract.java
+++ b/library/src/main/java/net/grandcentrix/tray/provider/TrayContract.java
@@ -16,9 +16,10 @@
 
 package net.grandcentrix.tray.provider;
 
-import net.grandcentrix.tray.R;
-
 import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.ProviderInfo;
 import android.net.Uri;
 import android.provider.BaseColumns;
 import android.support.annotation.NonNull;
@@ -120,8 +121,20 @@ class TrayContract {
 
     @NonNull
     private static String getAuthority(@NonNull final Context context) {
-        return TextUtils.isEmpty(sTestAuthority) ?
-                context.getString(R.string.tray__authority) :
-                sTestAuthority;
+        if (!TextUtils.isEmpty(sTestAuthority)) {
+            return sTestAuthority;
+        }
+        for (PackageInfo pack : context.getPackageManager().getInstalledPackages(PackageManager.GET_PROVIDERS)) {
+            ProviderInfo[] providers = pack.providers;
+            if (providers != null) {
+                for (ProviderInfo provider : providers) {
+                    if (TextUtils.equals(provider.authority,
+                            context.getApplicationContext().getPackageName() + ".tray")) {
+                        return provider.authority;
+                    }
+                }
+            }
+        }
+        return "com.example.preferences";
     }
 }

--- a/library/src/main/java/net/grandcentrix/tray/provider/TrayContract.java
+++ b/library/src/main/java/net/grandcentrix/tray/provider/TrayContract.java
@@ -18,6 +18,7 @@ package net.grandcentrix.tray.provider;
 
 import net.grandcentrix.tray.R;
 import net.grandcentrix.tray.core.TrayLog;
+import net.grandcentrix.tray.core.TrayRuntimeException;
 
 import android.content.Context;
 import android.content.pm.ProviderInfo;
@@ -26,7 +27,6 @@ import android.os.Process;
 import android.provider.BaseColumns;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
-import android.text.TextUtils;
 import android.util.Log;
 
 import java.util.List;
@@ -72,24 +72,12 @@ class TrayContract {
         String BASE_PATH = "internal_preferences";
     }
 
-    private static String sTestAuthority;
-
-    private static String sAuthority;
+    @VisibleForTesting
+    static String sAuthority;
 
     @NonNull
     public static Uri generateContentUri(@NonNull final Context context) {
         return generateContentUri(context, Preferences.BASE_PATH);
-    }
-
-    /**
-     * use this only for tests and not in production
-     *
-     * @param authority the new authority for Tray
-     * @see TrayContentProvider#setAuthority(String)
-     */
-    @VisibleForTesting
-    public static void setAuthority(final String authority) {
-        sTestAuthority = authority;
     }
 
     @NonNull
@@ -127,9 +115,6 @@ class TrayContract {
 
     @NonNull
     private static synchronized String getAuthority(@NonNull final Context context) {
-        if (!TextUtils.isEmpty(sTestAuthority)) {
-            return sTestAuthority;
-        }
         if (sAuthority != null) {
             return sAuthority;
         }
@@ -150,7 +135,7 @@ class TrayContract {
         }
 
         // Should never happen. Otherwise we implemented tray in a wrong way!
-        throw new RuntimeException("Internal tray error. "
+        throw new TrayRuntimeException("Internal tray error. "
                 + "Could not find the provider authority. "
                 + "Please fill an issue at https://github.com/grandcentrix/tray/issues");
     }

--- a/library/src/main/java/net/grandcentrix/tray/provider/TrayContract.java
+++ b/library/src/main/java/net/grandcentrix/tray/provider/TrayContract.java
@@ -124,17 +124,12 @@ class TrayContract {
         if (!TextUtils.isEmpty(sTestAuthority)) {
             return sTestAuthority;
         }
-        for (PackageInfo pack : context.getPackageManager().getInstalledPackages(PackageManager.GET_PROVIDERS)) {
-            ProviderInfo[] providers = pack.providers;
-            if (providers != null) {
-                for (ProviderInfo provider : providers) {
-                    if (TextUtils.equals(provider.authority,
-                            context.getApplicationContext().getPackageName() + ".tray")) {
-                        return provider.authority;
-                    }
-                }
-            }
+
+        final String authority = TrayContentProvider.mAuthority;
+        if(!TextUtils.isEmpty(authority)) {
+            return authority;
         }
+
         return "com.example.preferences";
     }
 }

--- a/library/src/main/java/net/grandcentrix/tray/provider/TrayContract.java
+++ b/library/src/main/java/net/grandcentrix/tray/provider/TrayContract.java
@@ -96,7 +96,7 @@ class TrayContract {
                     + "#########################################\n"
                     + "Don't set the authority with `tray__authority` in your build.gradle.\n"
                     + "To change the default authority override it inside the AndroidManifest\n"
-                    + "See https://github.com/grandcentrix/tray#set-the-authority for instructions\n"
+                    + "See https://github.com/grandcentrix/tray/wiki/Custom-Authority for instructions\n"
                     + "#########################################\n"
                     + "#########################################\n"
                     + "#########################################\n");

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -10,8 +10,6 @@ android {
         targetSdkVersion 23
         versionCode 1
         versionName "1.1"
-
-        resValue "string", "tray__authority", "net.grandcentrix.tray.sample.preferences"
     }
 
     buildTypes {

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -19,6 +19,12 @@
 
         <service android:name=".MultiProcessService" android:process=":otherProcess"/>
 
+        <!-- example for changing the authority -->
+        <!-- <provider
+            android:name="net.grandcentrix.tray.provider.TrayContentProvider"
+            android:authorities="your.custom.authority"
+            android:exported="false"
+            tools:replace="android:authorities" /> -->
     </application>
 
 </manifest>


### PR DESCRIPTION
This build on top of #81 but add the ability to override the default authority of `applicatonId.tray`.
You can check each commit of me. Hopefully I have separated in a good and readable way.

In case you miss something:
We will now use **always** the `applicaitonId.tray` as authority. This will be set inside the TrayContentProvider in `attachInfo()`. Since `ContentProvider`s lifecycle is as long as the process lives, it is a clean solution to cache the authority info inside the class.

You have the ability to override the default authority inside the `AndroidManifest`. I've added the instructions part how to do it inside the `AndroidManifest`.
> **Note:** You can't override the ContentProvider in each flavor inside the `build.gradle` anymore. If you want to override it for each flavor (or build-type) you have to create a new package with the specific `AndroidManifest` in it. I hope that is clear. If not, inform me. Maybe we have to update the `Readme` with more information about that behaviour...?!

I've also changed the "behaviour" if the `TrayContentProvider#mAuthority` is empty. We will now throw a `RuntimeException` here. It is a "safety" feature, in my option. Since the `ContentProvider` starts as a "first part" of you App it should never happen. Otherwise we implemented something wrong....

## How to test
Push that PR to your mavenLocal (or something like that). (Note: Change the library version. Otherwise you will get in trouble and/or you have maybe version conflicts.)
Create a new project and include tray like any other app.
Attach the debugger in `TrayContract#getAuthority` and take a look what they return.
The first run: Without any specific setup(!) will return your default `applicationId` + `.tray`.
Now create some build flavors and add `applicationIdSuffix` and run.
The second run: `TrayContract#getAuthority` should return `applicationId` + `applicationIdSuffix`  + `.tray`.

For legacy testing:
Add `resValue "string", "tray__authority", "my.custom.authority"` into your `build.gradle`. 
The third run: You will notice that we will use the same `authority` like above. But inform the user via `Logcat` that they use a legacy method to override the default authority.

Overriding:
To override just add the following code to your `AndoridManifest`:
```xml
        <provider
            android:name="net.grandcentrix.tray.provider.TrayContentProvider"
            android:authorities="your.custom.authority"
            android:exported="false"
            tools:replace="android:authorities" />
```
The fourth run: `getAuthority` will now return `your.custom.authoity`.
Overriding in build-flavors:
Create a new `AndroidManifest` inside `app/src/flavorName/` and put the following inside:
```xml
<manifest package="net.grandcentrix.testtray"
    xmlns:android="http://schemas.android.com/apk/res/android"
    xmlns:tools="http://schemas.android.com/tools">

    <application>

        <provider
            android:name="net.grandcentrix.tray.provider.TrayContentProvider"
            android:authorities="another.custom.provider"
            android:exported="false"
            tools:replace="android:authorities" />

    </application>

</manifest>
```
Run the two different flavors you have created.
The fifhst run (build falvor without the specific `AndroidManifest`: Should return the "default" overriding value. Which means  `your.custom.authority` (from the `src/main/AndroidManifest`)
The second (and last) run (flavor with the specific `AndroidManifest`: Should `another.custom.provider` (from the `src/buildFlavor/AndroidManifest`).

Hope I haven't miss something.
Otherwise: Feel free to merge 👍