### PR TITLE
Add a issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,21 @@
+[//]: # (We want to provide the best support with your issue. So please answer the following questions carefully)
+[//]: # (You don't have an issue but a remark or a feature? Please remove this default template and just write your text 😉)
+
+#### tray Version (E.g. 0.12.0)
+
+#### How have you setup tray (E.g. Initialized in Application.onCreate, in an Activity, BroadcastReceiver, IntentService, MainThread)
+
+#### Device(s) (E.g. Samsung Galaxy S8)
+
+#### Android Version (E.g. Marshmallow or better API 23)
+
+#### Stacktrace
+<details>
+  <summary>Stacktrace</summary>
+
+  ```
+  <!-- Please put your stracktrace in here -->
+  ```
+</details>
+
+#### Description (Just a place with additional information, more == better)


### PR DESCRIPTION
I've just added a issue template to guide users with issue a little bit.

You can see the template here https://github.com/StefMa/tray/issues/2
You can also just create a new issue on https://github.com/StefMa/tray/ and it will be shown to you...
