### PR TITLE
Fix: support querying provider authority regardless of the hosting ap…

### DIFF
--- a/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayProviderTestCase.java
+++ b/library/src/androidTest/java/net/grandcentrix/tray/provider/TrayProviderTestCase.java
@@ -24,6 +24,7 @@ import android.content.ContentProvider;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ProviderInfo;
 import android.content.res.Resources;
@@ -120,6 +121,15 @@ public abstract class TrayProviderTestCase extends ProviderTestCase2<TrayContent
                 public List<ProviderInfo> queryContentProviders(final String processName,
                         final int uid, final int flags) {
                     return mProviderInfos;
+                }
+    
+                @Override
+                public PackageInfo getPackageInfo(String packageName, int flags) throws NameNotFoundException {
+                    final PackageInfo pkgInfo = new PackageInfo();
+                    if(null != mProviderInfos) {
+                        pkgInfo.providers = mProviderInfos.toArray(new ProviderInfo[mProviderInfos.size()]);
+                    }
+                    return pkgInfo;
                 }
             };
         }

--- a/library/src/androidTest/java/net/grandcentrix/tray/publicapi/ReadDifferentFormat.java
+++ b/library/src/androidTest/java/net/grandcentrix/tray/publicapi/ReadDifferentFormat.java
@@ -78,7 +78,7 @@ public class ReadDifferentFormat extends TrayProviderTestCase {
             assertEquals(Long.MAX_VALUE, mPref.getInt(KEY));
             fail();
         } catch (WrongTypeException e) {
-            assertTrue(e.getMessage().contains("int"));
+            assertTrue(e.getMessage().contains("string"));
         }
     }
 

--- a/library/src/main/java/net/grandcentrix/tray/provider/TrayContract.java
+++ b/library/src/main/java/net/grandcentrix/tray/provider/TrayContract.java
@@ -21,15 +21,14 @@ import net.grandcentrix.tray.core.TrayLog;
 import net.grandcentrix.tray.core.TrayRuntimeException;
 
 import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.content.pm.ProviderInfo;
 import android.net.Uri;
-import android.os.Process;
 import android.provider.BaseColumns;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 import android.util.Log;
-
-import java.util.List;
 
 /**
  * Contract defining the data in the {@link TrayContentProvider}. Use {@link TrayProviderHelper} to
@@ -120,20 +119,23 @@ class TrayContract {
         }
 
         checkOldWayToSetAuthority(context);
-
-        // read all providers of the app and find the TrayContentProvider to read the authority
-        final List<ProviderInfo> providers = context.getPackageManager()
-                .queryContentProviders(context.getPackageName(), Process.myUid(), 0);
-        if (providers != null) {
-            for (ProviderInfo provider : providers) {
-                if (provider.name.equals(TrayContentProvider.class.getName())) {
-                    sAuthority = provider.authority;
-                    TrayLog.v("found authority: " + sAuthority);
-                    return sAuthority;
+    
+        try {
+            final PackageInfo pkgInfo = context.getPackageManager()
+                    .getPackageInfo(context.getPackageName(), PackageManager.GET_PROVIDERS);
+            if(null != pkgInfo.providers){
+                for (ProviderInfo provider : pkgInfo.providers) {
+                    if (provider.name.equals(TrayContentProvider.class.getName())) {
+                        sAuthority = provider.authority;
+                        TrayLog.v("found authority: " + sAuthority);
+                        return sAuthority;
+                    }
                 }
             }
+        } catch (final PackageManager.NameNotFoundException e) {
+            Log.e("Tray", "Unable to get PackageInfo of current package " + context.getPackageName(), e);
         }
-
+        
         // Should never happen. Otherwise we implemented tray in a wrong way!
         throw new TrayRuntimeException("Internal tray error. "
                 + "Could not find the provider authority. "


### PR DESCRIPTION
Tray's ContentProvider is currently running in app main process. But sometimes we need it to be run in another process (":service" for example). This fix allows the app developer to configure 'android:process' attribute of the Provider in manifest freely. 